### PR TITLE
Avoid alpha animation  disabling implicit animations when hiding the pie piece

### DIFF
--- a/VBPieChart/Classes/VBPiePiece.m
+++ b/VBPieChart/Classes/VBPiePiece.m
@@ -45,6 +45,7 @@
     self.label.fontSize = 10;
     self.label.alignmentMode = kCAAlignmentCenter;
     self.label.foregroundColor = [UIColor blackColor].CGColor;
+
     return self;
 }
 
@@ -237,7 +238,12 @@
                               delegate:self];
         [self __innerRadius:_outerRadius];
     }
+
+    // Create a transaction just to disable implicit animations
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
     [self setHidden:NO];
+    [CATransaction commit];
 }
 
 


### PR DESCRIPTION
There is a subtle animation bug that makes the animation a bit clunky (in particular on a real device at 1x speed, but you can observe it also in the simulator).
Please compare the 2 gif that shows the slow-down graph animation. Observe how the alpha of all the pieces (except for the first one) is animated producing a weird effect.
Before the fix
![beforefix](https://cloud.githubusercontent.com/assets/2708453/5427723/0c9d52cc-83aa-11e4-9ec2-019e3efe634a.gif)

After the fix
![afterfix](https://cloud.githubusercontent.com/assets/2708453/5427724/0ca809c4-83aa-11e4-84c7-8d49615704a2.gif)

ps: little trick to slow down animation directly on your simulator or device:
1- Pause the app with the debugger
2- run the following lldb command `p [(CALayer *)[[[[UIApplication sharedApplication] windows] objectAtIndex:0] layer] setSpeed:.1f]`
