### PR TITLE
- Fix issue when reloading chart with different content and colors

### DIFF
--- a/VBPieChart/Classes/VBPieChart.m
+++ b/VBPieChart/Classes/VBPieChart.m
@@ -167,6 +167,9 @@ static __inline__ CGFloat CGPointDistanceBetweenTwoPoints(CGPoint point1, CGPoin
     if (!_chartValues) {
         return;
     }
+
+    // Reset data table
+    self.chartsData = [NSMutableArray array];
     
     // Clean old layers
     NSArray *arraySublayers = [NSArray arrayWithArray:self.layer.sublayers];


### PR DESCRIPTION
When a chart is reloaded with different data and colors, a previous color is used sometimes.

The reload used method is 
_pieChart setChartValues:@[@{@"value": @(1), @"color": [UIColor colorWithHexString:kNoDataColor]}]
                        animation:YES options:VBPieChartAnimationFanAll | VBPieChartAnimationTimingEaseIn];